### PR TITLE
in-progress: #42

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,19 @@
+# ExpensesTrackerAI
+
+## What Is This
+
+ExpensesTrackerAI: simple native iOS personal finance app for couples. Inspired by Apple Health app. Tracking feel natural, insightful — Simple, Smart, Clear, unmistakably Apple.
+
+## Code organization
+
+- Views: UI only — no logic/data transform
+- ViewModels: business logic, filtering, calculations, state management
+- `Core/Foundation/` extensions: reusable utilities shared across app
+
+<claude-mem-context>
+# Memory Context
+
+# [ExpensesTracker] recent context, 2026-06-28 10:03pm GMT+6
+
+No previous sessions found.
+</claude-mem-context>

--- a/ExpensesTrackerPackage/Sources/UI/Home/HeroDashboard/Bar/SpendingBar.swift
+++ b/ExpensesTrackerPackage/Sources/UI/Home/HeroDashboard/Bar/SpendingBar.swift
@@ -9,7 +9,7 @@ import Foundation
 import SwiftUI
 
 struct SpendingBarSegment: Identifiable {
-    let id = UUID()
+    let id: String
     let color: Color
     let value: Double
 }
@@ -32,12 +32,13 @@ struct SpendingProportionalBar: View {
 
     var body: some View {
         GeometryReader { geo in
-            let availableWidth = geo.size.width - totalGap
+            let availableWidth = max(0, geo.size.width - totalGap)
             let cornerRadius = geo.size.height / 2
 
             HStack(spacing: gap) {
-                ForEach(Array(segments.enumerated()), id: \.element.id) { index, segment in
-                    let width = availableWidth * (segment.value / total)
+                ForEach(segments) { segment in
+                    let width = total > 0 ? availableWidth * (segment.value / total) : 0
+                    let index = segments.firstIndex(where: { $0.id == segment.id }) ?? 0
                     let isFirst = index == 0
                     let isLast = index == segments.count - 1
                     let opacity: Double = selectedIndex == nil || selectedIndex == index ? 1 : 0.25
@@ -47,27 +48,24 @@ struct SpendingProportionalBar: View {
                             RoundedRectangle(cornerRadius: cornerRadius)
                                 .fill(segment.color)
                         } else if isFirst {
-                            // Round left corners only
                             UnevenRoundedRectangle(
                                 topLeadingRadius: cornerRadius,
                                 bottomLeadingRadius: cornerRadius
                             )
                             .fill(segment.color)
                         } else if isLast {
-                            // Round right corners only
                             UnevenRoundedRectangle(
                                 bottomTrailingRadius: cornerRadius,
                                 topTrailingRadius: cornerRadius
                             )
                             .fill(segment.color)
                         } else {
-                            // No rounding for middle segments
                             Rectangle()
                                 .fill(segment.color)
                         }
                     }
                     .opacity(opacity)
-                    .animation(.easeInOut(duration: 2), value: selectedIndex)
+                    .animation(.easeInOut(duration: 0.2), value: selectedIndex)
                     .frame(
                         width: width,
                         height: geo.size.height
@@ -80,11 +78,11 @@ struct SpendingProportionalBar: View {
 
 #Preview {
     let segments = [
-        SpendingBarSegment(color: .red, value: 1),
-        SpendingBarSegment(color: .orange, value: 2),
-        SpendingBarSegment(color: .yellow, value: 1),
-        SpendingBarSegment(color: .green, value: 2),
-        SpendingBarSegment(color: .blue, value: 1)
+        SpendingBarSegment(id: "red", color: .red, value: 1),
+        SpendingBarSegment(id: "orange", color: .orange, value: 2),
+        SpendingBarSegment(id: "yellow", color: .yellow, value: 1),
+        SpendingBarSegment(id: "green", color: .green, value: 2),
+        SpendingBarSegment(id: "blue", color: .blue, value: 1)
     ]
     let total = segments.reduce(0) { $0 + $1.value }
     SpendingProportionalBar(segments: segments, total: total)

--- a/ExpensesTrackerPackage/Sources/UI/Home/HeroDashboard/HeroDashboardCard+Model.swift
+++ b/ExpensesTrackerPackage/Sources/UI/Home/HeroDashboard/HeroDashboardCard+Model.swift
@@ -27,7 +27,7 @@ struct HeroDashboardModel: Equatable {
         let category: CategoryModel
         
         func toSpendingBarSegment() -> SpendingBarSegment {
-            .init(color: category.color, value: amount)
+            .init(id: category.name, color: category.color, value: amount)
         }
     }
 }

--- a/ExpensesTrackerPackage/Sources/UI/Home/HeroDashboard/HeroDashboardCard.swift
+++ b/ExpensesTrackerPackage/Sources/UI/Home/HeroDashboard/HeroDashboardCard.swift
@@ -7,35 +7,49 @@
 
 import SwiftUI
 
+private func lerp(_ a: CGFloat, _ b: CGFloat, _ t: CGFloat) -> CGFloat { a + (b - a) * t }
+
 struct HeroDashboardCard: View {
     private let model: HeroDashboardModel
-    
+    let progress: CGFloat
+
     @State private var showDateRangePicker = false
     @Binding private var selectedPeriod: Calendar.Period
     @State private var selectedCategory: CategoryModel?
     @AppStorage(AppStorageKeys.currency.key) private var selectedCurrencyRaw: String = Currency.usd.rawValue
     @Environment(\.locale) private var locale
-    
+
+    @State private var headerHeight: CGFloat = 0
+    @State private var upperMenuFrame: CGRect = .zero
+
+    private let cardPadding: CGFloat = 16
+    // At full collapse TotalMoney renders at ~31pt (48pt × 0.55), matching the capsule row height
+    private let collapsedScale: CGFloat = 0.55
+
     var availablePickerPeriods: [Calendar.Period] { [.day, .week, .month, .year] }
-    
+
+    private var clampedProgress: CGFloat { min(max(progress, 0), 1) }
+    private var fadeProgress: CGFloat { min(clampedProgress * 2, 1) }
+
+    private var moneyValue: Money {
+        .init(
+            amount: model.chips.first { $0.category == selectedCategory }?.amount ?? model.total,
+            currency: .initialize(rawValue: selectedCurrencyRaw)
+        )
+    }
+
     var body: some View {
         if #available(iOS 26.0, *) {
             content
-                .background(
-                    .white,
-                    in: ConcentricRectangle(corners: .concentric(minimum: 24))
-                )
+                .background(.white, in: ConcentricRectangle(corners: .concentric(minimum: 24)))
         } else {
             content
-                .background(
-                    .white,
-                    in: RoundedRectangle(cornerRadius: 24)
-                )
+                .background(.white, in: RoundedRectangle(cornerRadius: 24))
         }
     }
-    
+
     private var content: some View {
-        VStack(alignment: .leading, spacing: 8) {
+        VStack(alignment: .leading, spacing: lerp(8, 4, clampedProgress)) {
             HStack {
                 if let selectedCategory {
                     Label(selectedCategory.name.uppercased(), systemImage: selectedCategory.icon)
@@ -49,38 +63,49 @@ struct HeroDashboardCard: View {
                         .font(.footnote.bold())
                         .foregroundStyle(.secondary)
                 }
-                
                 Spacer()
-                if #available(iOS 26.0, *) {
-                    upperMenu
-                        .glassEffect()
-                } else {
-                    upperMenu
+                Group {
+                    if #available(iOS 26.0, *) {
+                        upperMenu.glassEffect()
+                    } else {
+                        upperMenu
+                    }
                 }
+                .opacity(1 - fadeProgress)
+                .allowsHitTesting(fadeProgress < 1)
+                .accessibilityHidden(fadeProgress >= 1)
+                .onGeometryChange(for: CGRect.self) { $0.frame(in: .named("card")) } action: { upperMenuFrame = $0 }
             }
-            
-            TotalMoney(
-                money: .init(
-                    amount: model.chips.first { $0.category == selectedCategory }?.amount ?? model.total,
-                    currency: .initialize(rawValue: selectedCurrencyRaw)
-                )
+            .onGeometryChange(for: CGFloat.self, of: { $0.size.height }) { headerHeight = $0 }
+
+            CollapsibleTotalMoney(
+                money: moneyValue,
+                progress: clampedProgress,
+                headerHeight: headerHeight,
+                cardPadding: cardPadding,
+                collapsedScale: collapsedScale,
+                upperMenuFrame: upperMenuFrame
             )
-            .contentTransition(.numericText())
-            
+
             SpendingProportionalBar(
                 segments: model.chips.map { $0.toSpendingBarSegment() },
                 total: model.total,
                 selectedIndex: model.chips.firstIndex(where: { $0.category == selectedCategory })
             )
-            .frame(height: 10)
-            
-            ExpenseCategoryGrid(chips: model.chips)
-                .onCategorySelect { category in
-                    selectedCategory = category
-                }
-                .padding(.top, 8)
+            .frame(height: lerp(10, 5, clampedProgress))
+
+            CollapsibleCategoryGrid(
+                chips: model.chips,
+                progress: clampedProgress,
+                fadeProgress: fadeProgress
+            )
+            .onPreferenceChange(SelectedCategoryPreferenceKey.self) { category in
+                selectedCategory = category
+            }
+            .padding(.top, 8)
         }
-        .padding(16)
+        .padding(cardPadding)
+        .coordinateSpace(.named("card"))
         .sheet(isPresented: $showDateRangePicker) {
             DateRangePicker(
                 selectedPeriod: $selectedPeriod,
@@ -94,13 +119,12 @@ struct HeroDashboardCard: View {
         .animation(.easeInOut(duration: 0.3), value: selectedCategory)
         .onChange(of: model) { _, newValue in
             let hasChangesInCategories = !newValue.chips.contains { $0.category == selectedCategory }
-            
             if hasChangesInCategories {
                 selectedCategory = nil
             }
         }
     }
-    
+
     private var upperMenu: some View {
         Menu {
             Picker(.empty, selection: $selectedPeriod) {
@@ -108,7 +132,7 @@ struct HeroDashboardCard: View {
                     Text(period.descriptionResource)
                 }
             }
-            
+
             Button(.customPeriod) {
                 showDateRangePicker = true
             }
@@ -122,10 +146,11 @@ struct HeroDashboardCard: View {
         .background(.indigo.opacity(0.15), in: .capsule)
         .fixedSize(horizontal: true, vertical: false)
     }
-    
-    init(selectedPeriod: Binding<Calendar.Period>, model: HeroDashboardModel) {
+
+    init(selectedPeriod: Binding<Calendar.Period>, model: HeroDashboardModel, progress: CGFloat = 0) {
         self._selectedPeriod = selectedPeriod
         self.model = model
+        self.progress = progress
     }
 }
 
@@ -134,6 +159,83 @@ extension HeroDashboardCard {
         onPreferenceChange(SelectedCategoryPreferenceKey.self) { category in
             action(category)
         }
+    }
+}
+
+// MARK: - CollapsibleTotalMoney
+
+private struct CollapsibleTotalMoney: View {
+    let money: Money
+    let progress: CGFloat
+    let headerHeight: CGFloat
+    let cardPadding: CGFloat
+    let collapsedScale: CGFloat
+    let upperMenuFrame: CGRect
+
+    @State private var naturalSize: CGSize = .zero
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    var body: some View {
+        // Placeholder: holds vertical space in VStack and collapses it as progress increases.
+        // The visible TotalMoney is in an overlay so it floats freely above the collapsing frame.
+        TotalMoney(money: money)
+            .fixedSize(horizontal: false, vertical: true)
+            .onGeometryChange(for: CGSize.self, of: { $0.size }) { naturalSize = $0 }
+            .frame(height: naturalSize.height > 0 ? lerp(naturalSize.height, 0, progress) : nil)
+            .opacity(0)
+            .clipped()
+            .accessibilityHidden(true)
+            .overlay(alignment: .topLeading) {
+                TotalMoney(money: money)
+                    .contentTransition(.numericText())
+                    .fixedSize(horizontal: false, vertical: true)
+                    .opacity(
+                        reduceMotion
+                            ? (naturalSize.height > 0 && headerHeight > 0 ? 1 - progress : 0)
+                            : (naturalSize.height > 0 && headerHeight > 0 ? 1 : 0)
+                    )
+                    .scaleEffect(
+                        reduceMotion ? 1.0 : lerp(1.0, collapsedScale, progress),
+                        anchor: .topLeading
+                    )
+                    .offset(
+                        x: reduceMotion ? 0 : lerp(0, targetOffsetX, progress),
+                        y: reduceMotion ? 0 : lerp(0, targetOffsetY, progress)
+                    )
+                    .allowsHitTesting(false)
+            }
+    }
+
+    // Offsets are in CollapsibleTotalMoney-local space (origin = placeholder top-leading).
+    // At progress=0 → (0,0): TotalMoney stays at natural position.
+    // At progress=1 → moves to header trailing area where the upper menu sits.
+    private var targetOffsetX: CGFloat {
+        upperMenuFrame.maxX - naturalSize.width * collapsedScale - cardPadding
+    }
+
+    private var targetOffsetY: CGFloat {
+        upperMenuFrame.midY - naturalSize.height * collapsedScale / 2 - cardPadding - headerHeight
+    }
+}
+
+// MARK: - CollapsibleCategoryGrid
+
+private struct CollapsibleCategoryGrid: View {
+    let chips: [HeroDashboardModel.ChipModel]
+    let progress: CGFloat
+    let fadeProgress: CGFloat
+
+    @State private var naturalHeight: CGFloat = 0
+
+    var body: some View {
+        ExpenseCategoryGrid(chips: chips)
+            .opacity(1 - fadeProgress)
+            .allowsHitTesting(fadeProgress < 1)
+            .accessibilityHidden(fadeProgress >= 1)
+            .fixedSize(horizontal: false, vertical: true)
+            .onGeometryChange(for: CGFloat.self, of: { $0.size.height }) { naturalHeight = $0 }
+            .frame(height: naturalHeight > 0 ? lerp(naturalHeight, 0, progress) : nil)
+            .clipped()
     }
 }
 

--- a/ExpensesTrackerPackage/Sources/UI/Home/HomeView.swift
+++ b/ExpensesTrackerPackage/Sources/UI/Home/HomeView.swift
@@ -10,29 +10,43 @@ import SwiftData
 
 struct HomeView: View {
     @State private var viewModel: HomeViewModel
+    @State private var isTracking = false
+    @State private var collapseProgress: CGFloat = 0
+    @State private var collapseDistance: CGFloat = 0
+    @State private var sensitivity: CGFloat = 150
 
     @Environment(\.modelContext) private var context
     @Environment(\.locale) private var locale
     @Query(sort: \ExpenseDBModel.date, order: .reverse) private var expenses: [ExpenseDBModel]
 
+    @AppStorage(AppStorageKeys.currency.key) private var selectedCurrencyRaw: String = Currency.usd.rawValue
+    private var currency: Currency { .initialize(rawValue: selectedCurrencyRaw) }
+
     init(viewModel: HomeViewModel) {
         self.viewModel = viewModel
     }
-    
+
     var body: some View {
         VStack {
             HeroDashboardCard(
                 selectedPeriod: $viewModel.selectedPeriod,
-                model: viewModel.spendingHeroModel
+                model: viewModel.spendingHeroModel,
+                progress: collapseProgress
             )
             .onCategorySelect { category in
                 viewModel.selectedCategoryFilter = category
             }
             .padding(.horizontal, 16)
-            
+            .onGeometryChange(for: CGFloat.self, of: { $0.size.height }) { height in
+                // Only capture the expanded height; ignore changes caused by collapse itself.
+                if collapseProgress == 0 {
+                    sensitivity = height
+                }
+            }
+
             List {
                 let groups = viewModel.groupedExpenses
-                
+
                 if groups.isEmpty {
                     Section {
                         ExpenseListEmptyState(
@@ -47,7 +61,7 @@ struct HomeView: View {
                     ForEach(groups, id: \.date) { group in
                         Section {
                             ForEach(group.items) { expense in
-                                ExpenseListRow(expense: expense)
+                                ExpenseListRow(expense: expense, currency: currency)
                                     .swipeActions(
                                         edge: .trailing,
                                         allowsFullSwipe: true
@@ -63,7 +77,8 @@ struct HomeView: View {
                         } header: {
                             ExpenseListSectionHeader(
                                 label: group.date.relativeLabel(locale: locale),
-                                total: group.total
+                                total: group.total,
+                                currency: currency
                             )
                         }
                         .listSectionSpacing(8)
@@ -73,6 +88,23 @@ struct HomeView: View {
             .listStyle(.insetGrouped)
             .scrollContentBackground(.hidden)
             .modifier(SearchBehaviorModifier(searchText: $viewModel.searchText))
+            .scrollDismissesKeyboard(.interactively)
+            .onScrollGeometryChange(for: CGFloat.self, of: { $0.contentOffset.y }) { oldY, newY in
+                guard isTracking else { return }
+                guard !viewModel.groupedExpenses.isEmpty else { return }
+                let delta = newY - oldY
+                let newProgress = min(1, max(0, collapseProgress + delta / sensitivity))
+                collapseProgress = newProgress
+            }
+            .onScrollPhaseChange { oldPhase, newPhase in
+                isTracking = newPhase == .interacting
+                
+                if !isTracking {
+                    withAnimation(.spring(duration: 0.3)) {
+                        collapseProgress = collapseProgress > 0.5 ? 1 : 0
+                    }
+                }
+            }
         }
         .toolbar {
             ToolbarItemGroup(placement: .bottomBar) {
@@ -81,7 +113,7 @@ struct HomeView: View {
                     .modifier(AddExpenseButtonBehaviorModifier())
                 Spacer()
             }
-            
+
             ToolbarItem(placement: .topBarTrailing) {
                 Button {
                     viewModel.settingsButtonTapped()
@@ -119,7 +151,7 @@ struct HomeView: View {
         })
         .background(.background.secondary)
     }
-    
+
     private func deleteAction(expense: ExpenseDBModel) -> some View {
         Button(role: .destructive) {
             context.delete(expense)
@@ -127,7 +159,7 @@ struct HomeView: View {
             Label(.delete, systemImage: "trash")
         }
     }
-    
+
     private func editAction(expense: ExpenseDBModel) -> some View {
         Button {
             viewModel.editExpenese(expense)
@@ -143,4 +175,3 @@ struct HomeView: View {
         HomeView(viewModel: HomeViewModelImpl())
     }
 }
- 

--- a/ExpensesTrackerPackage/Sources/UI/Home/Views/ExpenseListViews+Preview.swift
+++ b/ExpensesTrackerPackage/Sources/UI/Home/Views/ExpenseListViews+Preview.swift
@@ -70,13 +70,14 @@ private extension ExpenseDBModel {
         ForEach(groups, id: \.0) { label, expenses in
             Section {
                 ForEach(expenses, id: \.id) { expense in
-                    ExpenseListRow(expense: expense)
+                    ExpenseListRow(expense: expense, currency: .usd)
                         .listRowInsets(.init())
                 }
             } header: {
                 ExpenseListSectionHeader(
                     label: label,
-                    total: expenses.reduce(0) { $0 + $1.amount }
+                    total: expenses.reduce(0) { $0 + $1.amount },
+                    currency: .usd
                 )
             }
         }
@@ -96,7 +97,8 @@ private extension ExpenseDBModel {
         ForEach(groups, id: \.0) { label, total in
             ExpenseListSectionHeader(
                 label: label,
-                total: total
+                total: total,
+                currency: .usd
             )
             Divider()
         }

--- a/ExpensesTrackerPackage/Sources/UI/Home/Views/ExpenseListViews.swift
+++ b/ExpensesTrackerPackage/Sources/UI/Home/Views/ExpenseListViews.swift
@@ -12,8 +12,7 @@ import SwiftUI
 struct ExpenseListSectionHeader: View {
     let label: String
     let total: Double
-    
-    @AppStorage(AppStorageKeys.currency.key) private var selectedCurrencyRaw: String = Currency.usd.rawValue
+    let currency: Currency
 
     var body: some View {
         HStack {
@@ -21,7 +20,7 @@ struct ExpenseListSectionHeader: View {
                 .font(.footnote.bold())
                 .foregroundStyle(.primary)
             Spacer()
-            Text(total.formatted(currency: .initialize(rawValue: selectedCurrencyRaw)))
+            Text(total.formatted(currency: currency))
                 .font(.footnote.bold())
                 .foregroundStyle(.primary)
         }
@@ -34,8 +33,8 @@ struct ExpenseListSectionHeader: View {
 
 struct ExpenseListRow: View {
     let expense: ExpenseDBModel
+    let currency: Currency
 
-    @AppStorage(AppStorageKeys.currency.key) private var selectedCurrencyRaw: String = Currency.usd.rawValue
     @Environment(\.locale) private var locale
 
     private var timeText: String {
@@ -46,7 +45,6 @@ struct ExpenseListRow: View {
         guard let desc = expense.notes?.desc, !desc.isEmpty else {
             return expense.category.name
         }
-        
         return desc
     }
 
@@ -80,7 +78,7 @@ struct ExpenseListRow: View {
 
             Spacer()
 
-            Text(expense.amount.formatted(currency: .initialize(rawValue: selectedCurrencyRaw)))
+            Text(expense.amount.formatted(currency: currency))
                 .font(.body.weight(.medium))
                 .foregroundStyle(.primary)
         }


### PR DESCRIPTION
Add AGENTS.md and refactor dashboard and list UI to support a collapsible header/compact state and safer rendering. Key changes:

- Added AGENTS.md project notes.
- SpendingBarSegment now uses a String id; bar now clamps available width, avoids divide-by-zero, finds segment index via firstIndex, and shortens animation duration.
- HeroDashboardCard: introduce progress-driven layout (collapseProgress), clamp/fade math, geometry tracking, coordinate space, and pass progress via initializer. Extract CollapsibleTotalMoney and CollapsibleCategoryGrid to handle animated collapsing, scaling, offsets, hit-testing and accessibility.
- HomeView: add collapse tracking state, compute collapseProgress from scroll events, animate snap open/closed, and pass selected currency into list rows/headers. Capture expanded height for sensitivity.
- Expense list views: propagate Currency explicitly into ExpenseListRow and ExpenseListSectionHeader and update previews.
- Misc: layout/padding tweaks, accessibility and animation improvements, and various small bug/edge-case fixes.

Overall purpose: enable a smooth, accessible collapsible hero dashboard, fix layout edge cases, and properly propagate currency rendering through list components.